### PR TITLE
Replace call to Slice#unsafe_at with call to Slice#unsafe_fetch

### DIFF
--- a/src/matrix/general_matrix.cr
+++ b/src/matrix/general_matrix.cr
@@ -59,7 +59,7 @@ module LA
     end
 
     def unsafe_at(i, j)
-      @raw.unsafe_at(i + j*nrows)
+      @raw.unsafe_fetch(i + j*nrows)
     end
 
     def unsafe_set(i, j, value)


### PR DESCRIPTION
Per https://github.com/crystal-lang/crystal/pull/6296, calls to Slice#unsafe_at need to be replaced with a call to Slice#unsafe_fetch.