### PR TITLE
Add ability to have nil-endpoint submatrix slices

### DIFF
--- a/spec/matrix_spec.cr
+++ b/spec/matrix_spec.cr
@@ -508,4 +508,33 @@ describe LA::Matrix do
     GMatComplex[[1, 2, 5], [10, 4, 1e-6 + 1e-6.i]].chop(1e-3).not_nil!.should eq GMat[[1, 2, 5], [10, 4, 1e-6]]
     GMatComplex[[1, 2, 5], [10, 4, 1e-6 + 1e-26.i]].chop.not_nil!.should eq GMat[[1, 2, 5], [10, 4, 1e-6]]
   end
+
+  it "can tolerate nil submatrix ranges" do
+    m = GMat32.new([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
+    #m1 = m[..3, 2..]
+    m1 = m[0..3, 2..3]
+    m1.size.should eq({4, 2})
+    m1[0, 0].should eq m[0, 2]
+    m1[0, 1].should eq m[0, 3]
+    m1[3, 0].should eq m[3, 2]
+    m1[3, 1].should eq m[3, 3]
+    m1[3, 1] = 10
+    m[3, 3].should eq 10
+    expect_raises(IndexError) do
+      m1[1, 2]
+    end
+    expect_raises(IndexError) do
+      m[-6..3, 2..3]
+    end
+    expect_raises(IndexError) do
+      m[0..3, 2..4]
+    end
+    m[1, ..1].should eq GMat32.new([[5, 6]])
+    m[.., 3].should eq m.columns[3]
+    m[.., 3].should eq GMat32.new([[4], [8], [12], [10]])
+    m[.., ..].should eq m
+    m[..., ...].should eq m
+    m[.., ...].should eq m
+    m[..., ..].should eq m
+  end
 end

--- a/src/matrix/matrix.cr
+++ b/src/matrix/matrix.cr
@@ -233,7 +233,7 @@ module LA
       end
     end
 
-    def [](i, j)
+    def [](i : Int32, j : Int32)
       i += nrows if i < 0
       j += ncolumns if j < 0
       if j >= 0 && j < ncolumns && i >= 0 && i < nrows
@@ -243,7 +243,7 @@ module LA
       end
     end
 
-    def []=(i, j, value)
+    def []=(i : Int32, j : Int32, value)
       i += nrows if i < 0
       j += ncolumns if j < 0
       if j >= 0 && j < ncolumns && i >= 0 && i < nrows
@@ -254,19 +254,36 @@ module LA
     end
 
     # return submatrix over given ranges.
-    def [](arows : Range(Int32, Int32), acolumns : Range(Int32, Int32))
+    def [](arows : Range(Int32 | Nil, Int32 | Nil), acolumns : Range(Int32 | Nil, Int32 | Nil))
+      arows_begin = arows.begin || 0
+      acolumns_begin = acolumns.begin || 0
+
+      arows_end = arows.end || nrows
+      if arows.end # compensate if user wanted the endpoint only if not nil
+        arows_end += arows.excludes_end? ? 0 : 1
+      end
+
+      acolumns_end = acolumns.end || ncolumns
+      if acolumns.end
+        acolumns_end += acolumns.excludes_end? ? 0 : 1
+      end
+
+      # ranges are converted to have int endpoints and are always exclusive
+      arows = arows_begin...arows_end
+      acolumns = acolumns_begin...acolumns_end
+      
       start_row = arows.begin + (arows.begin < 0 ? nrows : 0)
       start_col = acolumns.begin + (acolumns.begin < 0 ? ncolumns : 0)
-      total_rows = arows.end + (arows.excludes_end? ? 0 : 1) - start_row + (arows.end < 0 ? nrows : 0)
-      total_cols = acolumns.end + (acolumns.excludes_end? ? 0 : 1) - start_col + (acolumns.end < 0 ? ncolumns : 0)
+      total_rows = arows.end - start_row + (arows.end < 0 ? nrows : 0)
+      total_cols = acolumns.end - start_col + (acolumns.end < 0 ? ncolumns : 0)
       SubMatrix(T).new(self, {start_row, start_col}, {total_rows, total_cols})
     end
 
-    def [](row : Int32, acolumns : Range(Int32, Int32))
+    def [](row : Int32, acolumns : Range(Int32 | Nil, Int32 | Nil))
       self[row..row, acolumns]
     end
 
-    def [](arows : Range(Int32, Int32), column : Int32)
+    def [](arows : Range(Int32 | Nil, Int32 | Nil), column : Int32)
       self[arows, column..column]
     end
 


### PR DESCRIPTION
This patch allows one to have Nil-terminated ranges in the submatrix slicing operations. E.g. m[..,3] or m[2.., ...4]. Tests are included. Let me know what you think!